### PR TITLE
Show stream metadata and fix Play/Pause button in COntrol Center

### DIFF
--- a/Custer/player.swift
+++ b/Custer/player.swift
@@ -248,11 +248,14 @@ internal class Player: NSObject {
     private func setMetadata(title: String?) {
         
         var info = self.nowPlayingInfoCenter.nowPlayingInfo ?? [String: Any]()
+
+        // some radios use UPPERCASE titles -> Do Not Let Them Scream At Us
+        let capitalizedTitle = title?.capitalized
         
-        info[MPMediaItemPropertyTitle] = title ?? "Custer Radio"
+        info[MPMediaItemPropertyTitle] = capitalizedTitle ?? "Custer Radio"
         info[MPMediaItemPropertyArtist] = ""
-        
-        if let t = title {
+
+        if let t = capitalizedTitle {
             if t.contains(" - ") {
                 let data = t.components(separatedBy: " - ")
                 info[MPMediaItemPropertyArtist] = data[0]

--- a/Custer/player.swift
+++ b/Custer/player.swift
@@ -83,6 +83,7 @@ internal class Player: NSObject {
             }
         }
     }
+    
     private var state: player_state = .undefined {
         didSet {
             if let delegate = self.delegate {
@@ -158,7 +159,10 @@ internal class Player: NSObject {
                     return
                 }
                 
-                self.player = AVPlayer(playerItem: AVPlayerItem(asset: asset))
+                let playerItem = AVPlayerItem(asset: asset)
+                playerItem.addObserver(self, forKeyPath: "timedMetadata", options: .new, context: nil)
+                
+                self.player = AVPlayer(playerItem: playerItem)
                 self.state = .ready
                 self.player.volume = self.volume
                 
@@ -167,6 +171,17 @@ internal class Player: NSObject {
                 }
             }
         })
+    }
+    
+    // timedMetadata change handler, will update the stream metadata
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        guard keyPath == "timedMetadata" else { return }
+        guard let meta = self.player.currentItem?.timedMetadata else { return }
+        for metadata in meta {
+            if let title = metadata.value(forKey: "value") as? String {
+                setMetadata(title: title)
+            }
+        }
     }
     
     public func play() {
@@ -189,7 +204,7 @@ internal class Player: NSObject {
             self?.buffer(self?.player.currentItem?.totalBuffer() ?? -1, self?.player.currentItem?.currentBuffer() ?? -1)
         }
         
-        self.setMetadata()
+        self.nowPlayingInfoCenter.playbackState = .playing
     }
     
     public func pause() {
@@ -200,6 +215,9 @@ internal class Player: NSObject {
         self.player.pause()
         self.state = .paused
         self.pauseTimestamp = Date()
+        
+        self.nowPlayingInfoCenter.playbackState = .paused
+
         os_log(.debug, log: log, "player is paused")
     }
     
@@ -227,10 +245,21 @@ internal class Player: NSObject {
         self.reset(play: true)
     }
     
-    private func setMetadata() {
+    private func setMetadata(title: String?) {
+        
         var info = self.nowPlayingInfoCenter.nowPlayingInfo ?? [String: Any]()
         
-        info[MPMediaItemPropertyTitle] = "Custer - radio"
+        info[MPMediaItemPropertyTitle] = title ?? "Custer Radio"
+        info[MPMediaItemPropertyArtist] = ""
+        
+        if let t = title {
+            if t.contains(" - ") {
+                let data = t.components(separatedBy: " - ")
+                info[MPMediaItemPropertyArtist] = data[0]
+                info[MPMediaItemPropertyTitle] = data[1]
+            }
+        }
+        
         info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = player.currentTime().seconds
         info[MPMediaItemPropertyPlaybackDuration] = 9999999
         


### PR DESCRIPTION
Observe the timedMetadata key for metadata.
If there is a " - " in the string, assume it is "Artist - Title" and parse. Then fill 2 lines in the Control Center - looks nicer.
Fix the Play/Pause in the Control center.