### PR TITLE
[BugFix] Fix error on resume from sleep

### DIFF
--- a/Custer/player.swift
+++ b/Custer/player.swift
@@ -113,16 +113,16 @@ internal class Player: NSObject {
     }
     
     deinit {
-        guard self.observer != nil else {
-            return
-        }
-        
+        self.player.currentItem?.removeObserver(self, forKeyPath: "timedMetadata")
+
         if self.bufferObserver != nil {
             self.player.removeTimeObserver(self.bufferObserver!)
             self.bufferObserver = nil
         }
-        
-        NotificationCenter.default.removeObserver(self.observer!)
+
+        if self.observer != nil {
+            NotificationCenter.default.removeObserver(self.observer!)
+        }
     }
     
     private func streamInterrupted(notification: Notification) {
@@ -263,8 +263,7 @@ internal class Player: NSObject {
             }
         }
         
-        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = player.currentTime().seconds
-        info[MPMediaItemPropertyPlaybackDuration] = 9999999
+        info[MPNowPlayingInfoPropertyIsLiveStream] = 1.0
         
         DispatchQueue.main.async { [unowned self] in
           self.nowPlayingInfoCenter.nowPlayingInfo = info


### PR DESCRIPTION
[BugFix] Fix error on resume from sleep - https://github.com/exelban/custer/issues/4
Looks like proper pause on sleep and play on resume fixes this.

Other changes:
[Fix] Remove observer for timedMetadata.
[Improvement] Add LiveStream flag to NowPlayingInfoCenter to show "Live Stream" instead of the time hack.
